### PR TITLE
fix

### DIFF
--- a/src/main/java/com/tb/jwtdemo/config/SecurityConfig.java
+++ b/src/main/java/com/tb/jwtdemo/config/SecurityConfig.java
@@ -39,7 +39,7 @@ public class SecurityConfig {
 
 
     @Bean
-    public UserDetailsService userDetailsService() {
+    public static UserDetailsService userDetailsService() {
         return new UserInfoService();
     }
 
@@ -78,7 +78,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public PasswordEncoder passwordEncoder() {
+    public static PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 


### PR DESCRIPTION
It won't compile on my end, due to database stuff that isn't worth to debug for a separate branch, but this "should" fix the issue.
The problem: Spring calls `@Bean` annotated methods to actually get an object for injection. So, the `SecurityConfig` class requires the `JwtAuthFilter`; the `JwtAuthFilter` requires the `UserInfoService` ;  and the `UserInfoService` is provided by the `SecurityConfig.` So, `SecurityConfig` cannot provide the `UserInfoService` because `JwtAuthFilter` is not created and injected, and `JwtAuthFilter` cannot be created because `UserInfoService` cannot be created and injected, because the `SecurityConfig` instance doesn't exist to do so. Hence, the circular dependency.

So, the `static` solution in this PR sidesteps this issue, because static methods do not rely on an instance to be invoked.